### PR TITLE
Add sync action

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,0 +1,13 @@
+on: push
+jobs:
+  git-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: git-sync
+        uses: wei/git-sync@v3
+        with:
+          source_repo: "kubernetes/kubernetes"
+          destination_repo: "git@github.com:aks-lts/kubernetes.git"
+          source_branch: "refs/remotes/source/*"
+          destination_branch: "refs/heads/*"
+          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -1,4 +1,8 @@
-on: push
+# ref: https://github.com/marketplace/actions/git-sync-action
+on:
+  schedule: 
+    # sync every hour on the half hour
+    - cron: '30 * * * *'
 jobs:
   git-sync:
     runs-on: ubuntu-latest

--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -7,7 +7,7 @@ jobs:
   git-sync:
     runs-on: ubuntu-latest
     steps:
-      - name: git-sync
+      - name: git-sync-branches
         uses: wei/git-sync@v3
         with:
           source_repo: "kubernetes/kubernetes"
@@ -15,3 +15,12 @@ jobs:
           source_branch: "refs/remotes/source/*"
           destination_branch: "refs/heads/*"
           destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-tags
+        uses: wei/git-sync@v3
+        with:
+          source_repo: "kubernetes/kubernetes"
+          destination_repo: "git@github.com:aks-lts/kubernetes.git"
+          source_branch: "refs/tags/*"
+          destination_branch: "refs/tags/*"
+          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY` 
+     


### PR DESCRIPTION
This PR adds a GitHub action using git-sync to sync the upstream kubernetes repo with our fork every hour on the half hour. It uses a SSH Key which has been added to this repo as a GH Action secret (private key) and the as a deploy key which was added to the aks-lts/kuberentes repo as a deploy key (public key). 