### PR TITLE
change repo for sync action

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git-sync-branches
-        uses: jeremyrickard/git-sync@main
+        uses: aks-lts/git-sync@main
         with:
           source_repo: "kubernetes/kubernetes"
           destination_repo: "git@github.com:aks-lts/kubernetes.git"


### PR DESCRIPTION
I have moved my fork of git-sync into the `aks-lts` organization, so this PR updates the workflow to use the new reference