### PR TITLE
limit sync to release branches (what should we do for tags)

### DIFF
--- a/.github/workflows/repo-sync.yml
+++ b/.github/workflows/repo-sync.yml
@@ -7,15 +7,55 @@ jobs:
   git-sync:
     runs-on: ubuntu-latest
     steps:
-      - name: git-sync-branches
+      - name: git-sync-master-branch
         uses: aks-lts/git-sync@main
         with:
           source_repo: "kubernetes/kubernetes"
           destination_repo: "git@github.com:aks-lts/kubernetes.git"
-          source_branch: "refs/remotes/source/*"
-          destination_branch: "refs/heads/*"
+          source_branch: "master"
+          destination_branch: "master"
           destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
-      - name: git-sync-tags
+      - name: git-sync-release-1.27
+        uses: aks-lts/git-sync@main
+        with:
+            source_repo: "kubernetes/kubernetes"
+            destination_repo: "git@github.com:aks-lts/kubernetes.git"
+            source_branch: "release-1.27"
+            destination_branch: "release-1.27"
+            destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-release-1.28
+        uses: aks-lts/git-sync@main
+        with:
+            source_repo: "kubernetes/kubernetes"
+            destination_repo: "git@github.com:aks-lts/kubernetes.git"
+            source_branch: "release-1.28"
+            destination_branch: "release-1.28"
+            destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-release-1.29
+        uses: aks-lts/git-sync@main
+        with:
+            source_repo: "kubernetes/kubernetes"
+            destination_repo: "git@github.com:aks-lts/kubernetes.git"
+            source_branch: "release-1.29"
+            destination_branch: "release-1.29"
+            destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-release-1.30
+        uses: aks-lts/git-sync@main
+        with:
+          source_repo: "kubernetes/kubernetes"
+          destination_repo: "git@github.com:aks-lts/kubernetes.git"
+          source_branch: "release-1.30"
+          destination_branch: "release-1.30"
+          destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-release-1.31
+        uses: aks-lts/git-sync@main
+        with:
+            source_repo: "kubernetes/kubernetes"
+            destination_repo: "git@github.com:aks-lts/kubernetes.git"
+            source_branch: "release-1.31"
+            destination_branch: "release-1.31"
+            destination_ssh_private_key: ${{ secrets.DESTINATION_SSH_PRIVATE_KEY }} # optional, will override `SSH_PRIVATE_KEY`
+      - name: git-sync-tags #SHOULD WE RESTRICT TAGS? 
         uses: aks-lts/git-sync@main
         with:
           source_repo: "kubernetes/kubernetes"


### PR DESCRIPTION
This PR limits the sync of the repo to the release branches and master. This should prevent any inadvertent overwrites of branches we maintain for LTS.

TODO: do the same for tags? Maybe we should fork the action and support multiple branches/tags for source, otherwise we will need to repeat the action multiple times. 